### PR TITLE
Commiting first test case to reproduce the issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "1.43.0",
+    "@playwright/test": "^1.47.2",
     "@types/node": "^20.9.3",
     "dotenv": "^16.3.1"
   }

--- a/tests/inputFields.spec.ts
+++ b/tests/inputFields.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Input fields', () => {
+    test.beforeEach( async({page}) => {
+        await page.goto('/')
+        await page.getByTitle('pettypes').click()
+        await expect(page.locator('h2')).toHaveText('Pet Types')
+    })
+
+    test('Test Case 1: Update pet type', async ({page}) => {
+        //Creating locator for targeted table row that is going to be edited
+        const tableRow = page.locator('tbody tr')
+        await tableRow.getByRole('button',{name: "Edit"}).first().click()
+        //Asserting the "Edit Pet Type" text displayed
+        await expect(page.locator('h2')).toHaveText('Edit Pet Type')
+        //Creating a locator for input field that be cleared and inserted a new value
+        const nameInputField = page.getByRole('textbox')
+        await nameInputField.clear()
+        await nameInputField.fill('rabbit')
+        //Creating a locator for 'Update' button that we will use a few more times
+        const updateButton = page.getByRole('button', {name: "Update"})
+        await updateButton.click()
+        //Extracting a value of the name field
+        //Asserting (general) the value of the first row is updated
+        await expect(tableRow.locator('td input[id="0"]')).toHaveValue('rabbit')
+        //Now going to edit the same row again to back 'cat'
+        await tableRow.getByRole('button',{name: "Edit"}).first().click()
+        //Clearing 'rabbit' from the field and filling with 'cat' and clicking 'Update' button
+        await nameInputField.clear()
+        await nameInputField.fill('cat')
+        await updateButton.click()
+        //Then asserting the 'cat' value of the same row is updated
+        await expect(tableRow.locator('td input[id="0"]')).toHaveValue('cat')
+    })
+
+    // test('Test Case 2: Cancel pet type update', async ({page}) => {
+    // const tableRows = page.locator('tbody tr')
+    // await tableRows.filter({has: page.locator('td input[id="1"]')}).getByRole('button',{name: "Edit"}).click()
+    // });
+
+    // test('Test Case 3: Pet type name is required validation', async ({page}) => {
+    // const tableRows = page.locator('tbody tr')
+    // await tableRows.filter({has: page.locator('td input[id="2"]')}).getByRole('button',{name: "Edit"}).click()
+    // });
+})

--- a/tests/inputFields.spec.ts
+++ b/tests/inputFields.spec.ts
@@ -9,8 +9,8 @@ test.describe('Input fields', () => {
 
     test('Test Case 1: Update pet type', async ({page}) => {
         //Creating locator for targeted table row that is going to be edited
-        const tableRow = page.locator('tbody tr')
-        await tableRow.getByRole('button',{name: "Edit"}).first().click()
+        const tableRows = page.locator('tbody tr')
+        await tableRows.getByRole('button',{name: "Edit"}).first().click()
         //Asserting the "Edit Pet Type" text displayed
         await expect(page.locator('h2')).toHaveText('Edit Pet Type')
         //Creating a locator for input field that be cleared and inserted a new value
@@ -21,42 +21,40 @@ test.describe('Input fields', () => {
         //Creating a locator for 'Update' button that we will use a few more times
         const updateButton = page.getByRole('button', {name: "Update"})
         await updateButton.click()
-        //Extracting a value of the name field
         //Asserting the value of the first row is updated
-        await expect(tableRow.locator('td input[id="0"]')).toHaveValue('rabbit')
+        await expect(tableRows.locator('[id="0"]')).toHaveValue('rabbit')
         //Now going to edit the same row again to back 'cat'
-        await tableRow.getByRole('button',{name: "Edit"}).first().click()
+        await tableRows.getByRole('button',{name: "Edit"}).first().click()
         //Clearing 'rabbit' from the field and filling with 'cat' and clicking 'Update' button
         await nameInputField.click()
         await nameInputField.clear()
         await nameInputField.fill('cat')
         await updateButton.click()
         //Then asserting the 'cat' value of the same row is updated
-        await expect(tableRow.locator('td input[id="0"]')).toHaveValue('cat')
+        await expect(tableRows.locator('[id="0"]')).toHaveValue('cat')
     })
 
     test('Test Case 2: Cancel pet type update', async ({page}) => {
         //Creating locator for targeted table rows that is going to be edited
-        const tableRow = page.getByRole('row', { name: 'dog Edit Delete' })
-        await tableRow.getByRole('button').first().click()
+        const tableRows = page.getByRole('row', { name: 'dog' })
+        await tableRows.getByRole('button', {name: "Edit"}).click()
         //Clearing the field and filling 'moose'
-        const nameInputField = page.getByRole('textbox')
+        const nameInputField = page.locator('#name')
         await nameInputField.click()
         await nameInputField.clear()
         await nameInputField.fill('moose')
         //Asserting input value is 'moose'
-        const inputValue = await nameInputField.inputValue()
-        expect(inputValue).toEqual('moose')
+        await expect(nameInputField).toHaveValue('moose')
         //Clicking the 'Cancel' button
         await page.getByRole('button', {name: "Cancel"}).click()
         //Then asserting the 'dog' value is remaining for the same row
-        await expect(tableRow.locator('td input[id="1"]')).toHaveValue('dog')
+        await expect(tableRows.locator('[id="1"]')).toHaveValue('dog')
     });
 
     test('Test Case 3: Pet type name is required validation', async ({page}) => {
         //Creating locator for targeted table rows that is going to be edited
-        const tableRow = page.getByRole('row', { name: 'lizard Edit Delete' })
-        await tableRow.getByRole('button').first().click()
+        const tableRows = page.getByRole('row', { name: 'lizard' })
+        await tableRows.getByRole('button', {name: "Edit"}).click()
         //Clearing input field
         const nameInputField = page.getByRole('textbox')
         await nameInputField.click()

--- a/tests/inputFields.spec.ts
+++ b/tests/inputFields.spec.ts
@@ -15,17 +15,19 @@ test.describe('Input fields', () => {
         await expect(page.locator('h2')).toHaveText('Edit Pet Type')
         //Creating a locator for input field that be cleared and inserted a new value
         const nameInputField = page.getByRole('textbox')
+        await nameInputField.click()
         await nameInputField.clear()
         await nameInputField.fill('rabbit')
         //Creating a locator for 'Update' button that we will use a few more times
         const updateButton = page.getByRole('button', {name: "Update"})
         await updateButton.click()
         //Extracting a value of the name field
-        //Asserting (general) the value of the first row is updated
+        //Asserting the value of the first row is updated
         await expect(tableRow.locator('td input[id="0"]')).toHaveValue('rabbit')
         //Now going to edit the same row again to back 'cat'
         await tableRow.getByRole('button',{name: "Edit"}).first().click()
         //Clearing 'rabbit' from the field and filling with 'cat' and clicking 'Update' button
+        await nameInputField.click()
         await nameInputField.clear()
         await nameInputField.fill('cat')
         await updateButton.click()
@@ -33,13 +35,42 @@ test.describe('Input fields', () => {
         await expect(tableRow.locator('td input[id="0"]')).toHaveValue('cat')
     })
 
-    // test('Test Case 2: Cancel pet type update', async ({page}) => {
-    // const tableRows = page.locator('tbody tr')
-    // await tableRows.filter({has: page.locator('td input[id="1"]')}).getByRole('button',{name: "Edit"}).click()
-    // });
+    test('Test Case 2: Cancel pet type update', async ({page}) => {
+        //Creating locator for targeted table rows that is going to be edited
+        const tableRow = page.getByRole('row', { name: 'dog Edit Delete' })
+        await tableRow.getByRole('button').first().click()
+        //Clearing the field and filling 'moose'
+        const nameInputField = page.getByRole('textbox')
+        await nameInputField.click()
+        await nameInputField.clear()
+        await nameInputField.fill('moose')
+        //Asserting input value is 'moose'
+        const inputValue = await nameInputField.inputValue()
+        expect(inputValue).toEqual('moose')
+        //Clicking the 'Cancel' button
+        await page.getByRole('button', {name: "Cancel"}).click()
+        //Then asserting the 'dog' value is remaining for the same row
+        await expect(tableRow.locator('td input[id="1"]')).toHaveValue('dog')
+    });
 
-    // test('Test Case 3: Pet type name is required validation', async ({page}) => {
-    // const tableRows = page.locator('tbody tr')
-    // await tableRows.filter({has: page.locator('td input[id="2"]')}).getByRole('button',{name: "Edit"}).click()
-    // });
+    test('Test Case 3: Pet type name is required validation', async ({page}) => {
+        //Creating locator for targeted table rows that is going to be edited
+        const tableRow = page.getByRole('row', { name: 'lizard Edit Delete' })
+        await tableRow.getByRole('button').first().click()
+        //Clearing input field
+        const nameInputField = page.getByRole('textbox')
+        await nameInputField.click()
+        await nameInputField.clear()
+        //Extracting a text from a locator for an error message and asserting the text of an error message to be presented
+        const errorMessage = page.locator('.help-block')
+        await expect(errorMessage).toBeVisible()
+        await expect(errorMessage).toHaveText('Name is required')
+        //Click on the 'Update' button and making an assertion that "Edit Pet Type" page is still displayed
+        await page.getByRole('button', {name: "Update"}).click()
+        await expect(page.locator('h2')).toHaveText('Edit Pet Type')
+        //Clicking the 'Cancel' button
+        await page.getByRole('button', {name: "Cancel"}).click()
+        //Making an assertion that the 'Pet Types' page is displayed
+        await expect(page.locator('h2')).toHaveText('Pet Types')
+    });
 })


### PR DESCRIPTION
First homework assignment and the first test case. As I mentioned in Slack, there are issues with clearing and filling the input field. Sometimes it doesn't clear the field and results in 'catrabbit', sometimes the input name is not updating to a new one and the assertion is failing. I was running the test in debug and everything is working fine, but when running the same code it seems like PW is running too fast and FE cannot operate some actions.

Try to reproduce on your end and let me know if there is anything that I did wrong, please.
![after update name](https://github.com/user-attachments/assets/6f8a246b-e9f7-4499-8595-2b15eb83e7a5)
![code result](https://github.com/user-attachments/assets/62b45966-ca91-4515-8064-ccce18ca4513)


